### PR TITLE
feat: Virtual path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "sfab": "bin/sfab"
   },
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Static site generator. From markdown to html with metadata and handlebars.",
   "keywords": [
     "static",


### PR DESCRIPTION
fix: Run hooks during partial registration
feat: Virtual path. load pages if the site is running under a virtual path like https://hubotio.github.com/hubot by passing a value to the `--serve /hubot/` argument.